### PR TITLE
[G2M] notes - fix dash parsing error for category

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const chalk = require('chalk')
 
 
-const CAT_SEP = '-'
+const CAT_SEP = ' - '
 const TIER_SEP = '/'
 
 const getColors = (severity) => ({
@@ -28,7 +28,7 @@ module.exports.parseCommits = (logs) => {
       const [t1, ...t2] = cat.toLowerCase().split(TIER_SEP)
       acc[t1] = [
         ...(acc[t1] || []),
-        [t2.join(TIER_SEP), `${title.join(CAT_SEP)} (${h} by ${an})`].filter(s => s).join(' - '),
+        [t2.join(TIER_SEP), `${title.join(`\n&nbsp;&nbsp;${CAT_SEP}`)} (${h} by ${an})`].filter(s => s).join(' - '),
       ]
       return acc
     }, {})


### PR DESCRIPTION

- add newline and indentation for nested notes

Also added newline and spacing for nested commit messages:
![Screen Shot 2020-09-10 at 5 37 36 PM](https://user-images.githubusercontent.com/50936670/92811362-6002f900-f38c-11ea-8bba-84b83585a49c.png)