### PR TITLE
[G2M] Notes/regex parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `notes` - support commit message body (b386123 by Runzhou Li (woozyking))
+	* body is persed per line as list item and indented under its subject
+	* body lines that start with `- ` and `* ` are standardized as `- `
+- `notes` - A generic "others" category to capture all parser-unmatched (fe5bfb1 by Runzhou Li (woozyking))
+
+### Changed
+- `notes` - regex based parser (0488a32 by Runzhou Li (woozyking))
+
+### Fixed
+- `notes` - dash `-` parsing error for category (b57aedb by hyx131)
+
 ## [1.2.0] - 2020-08-21
 ### Added
 - `notes` - author name per commit

--- a/lib/command.notes.js
+++ b/lib/command.notes.js
@@ -36,9 +36,9 @@ const handler = ({ base, head, pattern, file, verbose }) => {
 
     const version = head || _head
     const previous = base || _base
-    cmd = `git log --no-merges --format='%h::%s::%an' ${version}...${previous}`
+    cmd = `git log --no-merges --format='%h::%s::%b::%an||' ${version}...${previous}`
     log(cmd, { verbose })
-    const logs = execSync(cmd).toString().trim().split('\n')
+    const logs = execSync(cmd).toString().trim().split('||').map(log => log.trim()).filter(log => log)
     const parsed = parseCommits(logs)
 
     const notes = formatNotes({ parsed, version, previous })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,15 +20,15 @@ const log  = (msg, { verbose, severity = 'info' }) => {
 }
 module.exports = { log }
 
-const parseSubject = (sbj) => {
+const parseSubject = (s) => {
   // TODO: find a more elegant way to capture both cases in one regex
-  let matches = sbj.match(T2R)
+  let matches = s.match(T2R)
   if (!matches || matches.some((v) => !v)) {
-    matches = sbj.match(T1R)
+    matches = s.match(T1R)
   }
   // unmatched to generic "others" category
   if (!matches) {
-    return ['others', sbj]
+    return ['others', s]
   }
   // with T2
   if (matches.length === 4) {
@@ -38,12 +38,18 @@ const parseSubject = (sbj) => {
   return matches.slice(1)
 }
 
+const parseBody = (b) => b.trim().split('\n').map(v => v.replace(/^(-|\*)\s/, '').trim()).filter(v => v)
+
 module.exports.parseCommits = (logs) => {
   try {
     return logs.reduce((acc, line) => {
-      const [h, sbj, an] = line.split('::')
-      const [t1, message] = parseSubject(sbj)
-      acc[t1] = [...(acc[t1] || []), `${message} (${h} by ${an})`]
+      const [h, s, b, an] = line.split('::')
+      const [t1, message] = parseSubject(s)
+      const msg = { s: `${message} (${h} by ${an})` }
+      if (b) {
+        msg.b = parseBody(b)
+      }
+      acc[t1] = [...(acc[t1] || []), msg]
       return acc
     }, {})
   } catch(e) {
@@ -57,8 +63,11 @@ module.exports.formatNotes = ({ parsed, version, previous }) => {
 
   Object.entries(parsed).forEach(([t1, item]) => {
     notes += `\n\n### ${t1}\n`
-    item.forEach((msg) => {
-      notes += `\n* ${msg}`
+    item.forEach(({ s, b = [] }) => {
+      notes += `\n* ${s}`
+      b.forEach((v) => {
+        notes += `\n\t* ${v}`
+      })
     })
   })
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,8 +3,8 @@ const fs = require('fs')
 const chalk = require('chalk')
 
 
-const CAT_SEP = ' - '
-const TIER_SEP = '/'
+const T2R = /(\S+)\/{1}(\S+) - (.*)/
+const T1R = /(\S+) - (.*)/
 
 const getColors = (severity) => ({
   info: { bgColor: 'bgCyanBright', color: 'black' },
@@ -20,16 +20,26 @@ const log  = (msg, { verbose, severity = 'info' }) => {
 }
 module.exports = { log }
 
+const parseSubject = (sbj) => {
+  // TODO: find a more elegant way to capture both cases in one regex
+  let matches = sbj.match(T2R)
+  if (!matches || matches.some((v) => !v)) {
+    matches = sbj.match(T1R)
+  }
+  // with T2
+  if (matches.length === 4) {
+    const [, cat, t2, title] = matches
+    return [cat, [t2, title].join(' - ')]
+  }
+  return matches.slice(1)
+}
+
 module.exports.parseCommits = (logs) => {
   try {
     return logs.reduce((acc, line) => {
       const [h, sbj, an] = line.split('::')
-      const [cat, ...title] = sbj.split(CAT_SEP).map(v => v.trim())
-      const [t1, ...t2] = cat.toLowerCase().split(TIER_SEP)
-      acc[t1] = [
-        ...(acc[t1] || []),
-        [t2.join(TIER_SEP), `${title.join(`\n&nbsp;&nbsp;${CAT_SEP}`)} (${h} by ${an})`].filter(s => s).join(' - '),
-      ]
+      const [t1, message] = parseSubject(sbj)
+      acc[t1] = [...(acc[t1] || []), `${message} (${h} by ${an})`]
       return acc
     }, {})
   } catch(e) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,6 +26,10 @@ const parseSubject = (sbj) => {
   if (!matches || matches.some((v) => !v)) {
     matches = sbj.match(T1R)
   }
+  // unmatched to generic "others" category
+  if (!matches) {
+    return ['others', sbj]
+  }
   // with T2
   if (matches.length === 4) {
     const [, cat, t2, title] = matches


### PR DESCRIPTION
result looks like:

## Release Notes: from v1.2.0 to HEAD

### notes

* add - support commit message body (d3f8be5 by Runzhou Li (woozyking))
	* body is persed per line as list item and indented under its subject
	* body lines that start with `- ` and `* ` are standardized as `- `
* add - a generic "others" category to capture all parser-unmatched (fe5bfb1 by Runzhou Li (woozyking))
* change - regex based parser (0488a32 by Runzhou Li (woozyking))
* fix dash parsing error for category - add newline and indentation for nested notes (b57aedb by hyx131)
