### PR TITLE
[G2M] use github release to release notes on github release :yodawg:

### DIFF
--- a/.github/workflows/npm-alpha.yml
+++ b/.github/workflows/npm-alpha.yml
@@ -6,20 +6,7 @@ on:
       - 'v*-alpha*'
 
 jobs:
-  publish-npm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org/
-      - run: yarn install
-      - run: yarn publish --tag alpha --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.CD_NPM_TOKEN_PUBLISH}}
-
-  publish-gpr:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +14,21 @@ jobs:
         with:
           node-version: 12
           registry-url: https://npm.pkg.github.com/
+          scope: '@eqworks'
+          always-auth: true
       - run: yarn install
-      - run: yarn publish --tag alpha --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}
+      - run: yarn publish --access public --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+          scope: '@eqworks'
+          always-auth: true
+      - run: yarn publish --access public --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.CD_NPM_TOKEN_PUBLISH }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -7,28 +7,39 @@ on:
       - '!v*-*' # skips eg: v1.2.99-beta1, v3.5.0-test, etc.
 
 jobs:
-  publish-npm:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
         with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org/
-      - run: yarn install
-      - run: yarn publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.CD_NPM_TOKEN_PUBLISH}}
+          fetch-depth: 0
 
-  publish-gpr:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12
           registry-url: https://npm.pkg.github.com/
+          scope: '@eqworks'
+          always-auth: true
       - run: yarn install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}
       - run: yarn publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+          scope: '@eqworks'
+          always-auth: true
+      - run: yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.CD_NPM_TOKEN_PUBLISH }}
+
+      - name: Generate tag associated release notes
+        if: ${{ success() }}
+        run: npx @eqworks/release@alpha notes -v --head ${GITHUB_REF##*/} --github --skip alpha
+        env:
+          GITHUB_OWNER: EQWorks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `notes` - `--github, --gh` flag to redirect file output to updating the head ref (tag) associated GitHub release.
+- `notes` - `--github, --gh` flag to redirect file output to updating the head ref (tag) associated GitHub release
 	* Requires valid `$GITHUB_TOKEN` and `$GITHUB_OWNER` environment variables
 	* Support `$GITHUB_REPO` environment variable, but default to git local toplevel name
+- `notes` - `--fetch` flag to control whether to run git fetch before the rest fo the command
 
 ## [1.4.0] - 2020-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `notes` - `--github, --gh` flag to redirect file output to updating the head ref (tag) associated GitHub release.
+	* Requires valid `$GITHUB_TOKEN` and `$GITHUB_OWNER` environment variables
+	* Support `$GITHUB_REPO` environment variable, but default to git local toplevel name
+
 ## [1.4.0] - 2020-09-14
 
 ### Changed

--- a/lib/command.notes.js
+++ b/lib/command.notes.js
@@ -1,17 +1,16 @@
-const { execSync } = require('child_process')
-
-const { parseCommits, formatNotes, writeNotes, log } = require('./utils')
+const { parseCommits, formatNotes, writeNotes, log, exec } = require('./utils')
+const { updateRelease } = require('./github')
 
 
 const options = (yargs) => {
   yargs.option('base', {
     type: 'string',
     default: null,
-    description: 'base ref, default second latest tag',
+    description: 'base ref, default second latest tag of the given --pattern',
   }).option('head', {
     type: 'string',
     default: null,
-    description: 'head ref, default latest tag',
+    description: 'head ref, default latest tag of the given --pattern',
   }).option('pattern', {
     type: 'string',
     default: 'v*',
@@ -26,6 +25,11 @@ const options = (yargs) => {
     alias: 's',
     describe: 'One or more keywords to skip from the given pattern match',
     default: [],
+  }).option('github', {
+    type: 'boolean',
+    alias: 'gh',
+    description: 'Flag to redirect file output to updating the head ref (tag) associated GitHub release',
+    default: false,
   }).option('verbose', {
     type: 'boolean',
     alias: 'v',
@@ -34,30 +38,35 @@ const options = (yargs) => {
   })
 }
 
-const handler = ({ base, head, pattern, file, skip, verbose }) => {
+const handler = async ({ base, head, pattern, file, skip, github, fetch, verbose }) => {
+  const _exec = exec({ verbose })
   try {
-    let cmd = 'git fetch --prune'
-    log(cmd, { verbose })
-    execSync(cmd)
+    _exec('git fetch --prune')
 
-    cmd = `git tag -il '${pattern}' --cleanup=strip --sort version:refname`
+    let cmd = `git tag -il '${pattern}' --cleanup=strip --sort version:refname`
     if (skip.length) {
       cmd += ` | grep -v '${skip.join('\\|')}'`
     }
     cmd += ' | tail -2'
-    log(cmd, { verbose })
-    const [_base, _head] = execSync(cmd).toString().trim().split('\n')
+    const [_base, _head] = _exec(cmd).toString().trim().split('\n')
 
-    const version = (head || _head).trim()
-    const previous = (base || _base).trim()
+    const version = (head || _head || '').trim()
+    const previous = (base || _base || '').trim()
     cmd = `git log --no-merges --format='%h::%s::%b::%an||' ${version}...${previous}`
-    log(cmd, { verbose })
-    const logs = execSync(cmd).toString().trim().split('||').map(log => log.trim()).filter(log => log)
+    const logs = _exec(cmd).toString().trim().split('||').map(log => log.trim()).filter(log => log)
     const parsed = parseCommits(logs)
 
     const notes = formatNotes({ parsed, version, previous })
-    writeNotes({ notes, version, previous, file })
+
+    if (!github) {
+      writeNotes({ notes, version, previous, file })
+    } else {
+      await updateRelease({ notes, tag: version, verbose })
+    }
   } catch(err) {
+    if (verbose) {
+      console.error(err)
+    }
     log(err, { severity: 'error' })
   }
 }

--- a/lib/command.notes.js
+++ b/lib/command.notes.js
@@ -30,6 +30,10 @@ const options = (yargs) => {
     alias: 'gh',
     description: 'Flag to redirect file output to updating the head ref (tag) associated GitHub release',
     default: false,
+  }).option('fetch', {
+    type: 'boolean',
+    description: 'Perform a `git fetch --prune` before carrying out the rest of the command',
+    default: true,
   }).option('verbose', {
     type: 'boolean',
     alias: 'v',
@@ -41,7 +45,9 @@ const options = (yargs) => {
 const handler = async ({ base, head, pattern, file, skip, github, fetch, verbose }) => {
   const _exec = exec({ verbose })
   try {
-    _exec('git fetch --prune')
+    if (fetch) {
+      _exec('git fetch --prune')
+    }
 
     let cmd = `git tag -il '${pattern}' --cleanup=strip --sort version:refname`
     if (skip.length) {

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,0 +1,38 @@
+const { Octokit } = require('@octokit/core')
+
+const { exec, log } = require('./utils')
+
+
+const { GITHUB_TOKEN, GITHUB_OWNER: owner, GITHUB_REPO } = process.env
+
+module.exports.updateRelease = async ({ notes, tag, verbose }) => {
+  if (!GITHUB_TOKEN) {
+    throw new Error('$GITHUB_TOKEN not set')
+  }
+
+  if (!owner) {
+    throw new Error('$GITHUB_OWNER not set')
+  }
+
+  const _exec = exec({ verbose })
+  const octokit = new Octokit({ auth: GITHUB_TOKEN })
+
+  const repo = GITHUB_REPO || _exec('basename `git rev-parse --show-toplevel`').toString().trim()
+
+  const { data: { name, id: release_id } } = await octokit.request('GET /repos/:owner/:repo/releases/tags/:tag', {
+    owner,
+    repo,
+    tag,
+  })
+  log(`Release ${name} (ID: ${release_id}) found based on tag: ${tag}`, { verbose })
+
+  if (release_id) {
+    await octokit.request('PATCH /repos/:owner/:repo/releases/:release_id', {
+      owner,
+      repo,
+      release_id,
+      body: notes,
+    })
+    log(`Release ${name} (ID: ${release_id}) updated with notes: ${notes}`, { verbose })
+  }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const { execSync } = require('child_process')
 
 const chalk = require('chalk')
 
@@ -11,13 +12,18 @@ const getColors = (severity) => ({
   error: { bgColor: 'bgRedBright', color: 'white' },
 }[severity] || { bgColor: 'bgWhite', color: 'black' })
 
-const log  = (msg, { verbose, severity = 'info' }) => {
+const log  = (msg, { verbose = false, severity = 'info' } = {}) => {
   if (verbose || severity === 'error') {
     const { bgColor, color } = getColors(severity)
     console[severity === 'error' ? severity : 'log'](chalk[bgColor][color](msg))
   }
 }
 module.exports = { log }
+
+module.exports.exec = ({ verbose }) => (cmd) => {
+  log(cmd, { verbose })
+  return execSync(cmd)
+}
 
 const parseSubject = (s) => {
   const matches = s.match(R)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "1.4.0",
+  "version": "1.5.0-alpha.0",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",
@@ -17,6 +17,7 @@
     "prepublishOnly": "yarn lint"
   },
   "dependencies": {
+    "@octokit/core": "^3.1.2",
     "chalk": "^4.1.0",
     "yargs": "^15.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "1.5.0-alpha.0",
+  "version": "1.5.0",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,82 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@octokit/auth-token@^2.4.0":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.2.tgz#10d0ae979b100fa6b72fa0e8e63e27e6d0dbff8a"
+  integrity sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==
+  dependencies:
+    "@octokit/types" "^5.0.0"
+
+"@octokit/core@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.1.2.tgz#c937d5f9621b764573068fcd2e5defcc872fd9cc"
+  integrity sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==
+  dependencies:
+    "@octokit/auth-token" "^2.4.0"
+    "@octokit/graphql" "^4.3.1"
+    "@octokit/request" "^5.4.0"
+    "@octokit/types" "^5.0.0"
+    before-after-hook "^2.1.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.6.tgz#4f09f2b468976b444742a1d5069f6fa45826d999"
+  integrity sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==
+  dependencies:
+    "@octokit/types" "^5.0.0"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.3.1":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.6.tgz#708143ba15cf7c1879ed6188266e7f270be805d4"
+  integrity sha512-Rry+unqKTa3svswT2ZAuqenpLrzJd+JTv89LTeVa5UM/5OX8o4KTkPL7/1ABq4f/ZkELb0XEK/2IEoYwykcLXg==
+  dependencies:
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/request-error@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.2.tgz#0e76b83f5d8fdda1db99027ea5f617c2e6ba9ed0"
+  integrity sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==
+  dependencies:
+    "@octokit/types" "^5.0.1"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.0":
+  version "5.4.9"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.9.tgz#0a46f11b82351b3416d3157261ad9b1558c43365"
+  integrity sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^5.0.0"
+    deprecation "^2.0.0"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    once "^1.4.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/types@^5.0.0", "@octokit/types@^5.0.1":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.5.0.tgz#e5f06e8db21246ca102aa28444cdb13ae17a139b"
+  integrity sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==
+  dependencies:
+    "@types/node" ">= 8"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/node@>= 8":
+  version "14.11.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.1.tgz#56af902ad157e763f9ba63d671c39cda3193c835"
+  integrity sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw==
 
 acorn-jsx@^5.2.0:
   version "5.2.0"
@@ -96,6 +168,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+before-after-hook@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
+  integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -214,6 +291,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deprecation@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -533,6 +615,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -625,7 +712,12 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-once@^1.3.0:
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -909,6 +1001,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
this [release](https://github.com/EQWorks/release/releases/tag/v1.5.0-alpha.0) body was the result of dogfooding the `--github` feature by running:

```shell
% GITHUB_TOKEN=<redacted> GITHUB_OWNER=eqworks node index.js notes -v --gh

git fetch --prune
From github.com:EQWorks/release-notes-util
 * [new tag]         v1.5.0-alpha.0 -> v1.5.0-alpha.0
git tag -il 'v*' --cleanup=strip --sort version:refname | tail -2
git log --no-merges --format='%h::%s::%b::%an||' v1.5.0-alpha.0...v1.4.0
basename `git rev-parse --show-toplevel`
Release v1.5.0-alpha.0 (ID: 31628979) found based on tag: v1.5.0-alpha.0
Release v1.5.0-alpha.0 (ID: 31628979) updated with notes: ## Release Notes: from v1.4.0 to v1.5.0-alpha.0

### notes

* `--fetch` flag to control whether to run git fetch (28550c9 by Runzhou Li (woozyking))
* `--github` flag to update the head ref associated GitHub release (21d6278 by Runzhou Li (woozyking))
	* omit local file output
	* factor out `utils.exec` to perform `execSync` and `log`
	* requires `$GITHUB_TOKEN`, `$GITHUB_OWNER`, and `$GITHUB_REPO` env vars
	* `$GITHUB_REPO` falls back to local repo toplevel name
```