### PR TITLE
[G2M]Standardize

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,7 +37,7 @@ const parseSubject = (s) => {
   }
   // with T2
   const { groups: { cat, t2, title } } = matches
-  return [cat, t2, title]
+  return [cat.toLowerCase(), t2, title]
 }
 
 const parseBody = (b) => b.trim().split('\n').map(v => v.replace(/^(-|\*)\s/, '').trim()).filter(v => v)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,20 +71,34 @@ module.exports.parseCommits = async ({ logs, verbose = false }) => {
 }
 
 module.exports.formatNotes = ({ parsed, version, previous }) => {
-  // group by T1, enrich msg with label
+  // group by T1 & T2, enrich msg with label
   const byT1 = parsed.reduce((acc, { t1, labels, msg }) => {
-    acc[t1] = [...(acc[t1] || []), { ...msg, labels }]
+    // to organize commits without T2
+    const t2 = msg['t2'] ? msg.t2 : 'others'
+    delete msg.t2
+    acc[t1] = {
+      ...acc[t1],
+      [t2]: [...(acc[t1] ? acc[t1][t2] || [] : []), { ...msg, labels }],
+    }
     return acc
   }, {})
+
   // construct notes
   let notes = `## Release Notes: from ${previous} to ${version}`
-  Object.entries(byT1).forEach(([t1, item]) => {
-    notes += `\n\n### ${t1}\n`
-    item.forEach(({ labels, t2, s, b = [] }) => {
-      notes += `\n* ${(labels || []).length ? `[${labels.join(', ')}] ` : ''}`
-      notes += `${t2 ? `${t2} - ` : ''}${s}`
-      b.forEach((v) => {
-        notes += `\n\t* ${v}`
+
+  Object.entries(byT1).forEach(([t1, grouped]) => {
+    notes += `\n\n ### ${t1}\n`
+
+    Object.entries(grouped).forEach(([t2, item]) => {
+      // commits without T2 skip the title
+      notes += t2 === 'others' ? '' : `\n * #### ${t2}\n`
+
+      item.forEach(({ labels, s, b = [] }) => {
+        notes += `\n   * ${(labels || []).length ? `[${labels.join(', ')}] ` : ''}`
+        notes += `${s}`
+        b.forEach((v) => {
+          notes += `\n\t    * ${v}`
+        })
       })
     })
   })


### PR DESCRIPTION
- make T1 standard lower case
- also group by T2 (standard to lowercase as well)
- if the commit doesn't have T2, organized as `others` 
<img width="493" alt="Screen Shot 2020-10-09 at 12 53 19 PM" src="https://user-images.githubusercontent.com/53827690/95612113-d6992200-0a30-11eb-9bb1-543a1e015b3b.png">

- when putting the notes together, skip `others` and expose in the same hierarchy as T2
- if the commit has body, indent another level
<img width="598" alt="Screen Shot 2020-10-09 at 1 08 00 PM" src="https://user-images.githubusercontent.com/53827690/95612109-d567f500-0a30-11eb-9a0c-fcd1adf1a95a.png">
