### PR TITLE
[G2M]common/github - order tags by release date instead of version name

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -61,12 +61,12 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
       _exec('git fetch --prune')
     }
 
-    let cmd = `git tag -il '${pattern}' --cleanup=strip --sort version:refname`
+    let cmd = `git tag -il '${pattern}' --cleanup=strip --sort=-committerdate`
     if (skip.length) {
       cmd += ` | grep -v '${skip.join('\\|')}'`
     }
-    cmd += ' | tail -2'
-    const [_base, _head] = _exec(cmd).toString().trim().split('\n')
+    cmd += ' | head -2'
+    const [_head, _base] = _exec(cmd).toString().trim().split('\n')
 
     const version = (head || _head || '').trim()
     const previous = (base || _base || '').trim()


### PR DESCRIPTION
not to rely on tag name, order by creation
WARNING: haven't tested with the `grep` command for `--skip` but I'm assuming it'd work the same