### PR TITLE
[G2M]lib/parse-subject - fix t2 when no match by default it to 'others'

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,7 @@ const parseSubject = (s) => {
   const matches = s.match(R)
   // unmatched to generic "others" category
   if (!matches) {
-    return ['others', s]
+    return ['others', 'others', s]
   }
   // with T2
   const { groups: { cat, t2, title } } = matches


### PR DESCRIPTION
adds default value `others` to t2 when no matches so down in `formatNotes` it skips tier 2 completely https://github.com/EQWorks/release/blob/2721eba4680c299ddaaea6d8f7f293595d6d7d65/lib/utils.js#L94