### PR TITLE
[G2M]t2/format - adjust spacing around md format for t2

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,17 +87,17 @@ module.exports.formatNotes = ({ parsed, version, previous }) => {
   let notes = `## Release Notes: from ${previous} to ${version}`
 
   Object.entries(byT1).forEach(([t1, grouped]) => {
-    notes += `\n\n ### ${t1}\n`
+    notes += `\n\n### ${t1}\n`
 
     Object.entries(grouped).forEach(([t2, item]) => {
       // commits without T2 skip the title
-      notes += t2 === 'others' ? '' : `\n * #### ${t2}\n`
+      notes += t2 === 'others' ? '\n* ' : `\n* #### ${t2}\n\t* `
 
       item.forEach(({ labels, s, b = [] }) => {
-        notes += `\n   * ${(labels || []).length ? `[${labels.join(', ')}] ` : ''}`
+        notes += `${(labels || []).length ? `[${labels.join(', ')}] ` : ''}`
         notes += `${s}`
         b.forEach((v) => {
-          notes += `\n\t    * ${v}`
+          notes += `\n\t\t* ${v}`
         })
       })
     })


### PR DESCRIPTION
instead of spaced md
```
 ### version

   * [FEATURES, PERFECTIVE] v3.0.0 (b2156bd by Tamires)

 ### lib

 * #### parse-subject

   * [CORRECTIVE, PERFECTIVE] fix t2 when no match by default it to 'others' (3593397 by Tamires Lowande)
 * #### parseCommits

   * [FEATURES, PERFECTIVE] update to the newly trained sub-1MB NLP model (d7c4a1e by Runzhou Li (woozyking))
```
removed initial space of each line

```
### version

* [CHANGED, ADDED] v3.0.0 (b2156bd by Tamires)

### lib

* #### parse-subject
	* [FIXED, CHANGED] fix t2 when no match by default it to 'others' (3593397 by Tamires Lowande)
* #### parseCommits
	* [ADDED, CHANGED] update to the newly trained sub-1MB NLP model (d7c4a1e by Runzhou Li (woozyking))
```