### PR TITLE
[G2M]devops - add gh action to auto release tag based on commit message

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -80,14 +80,3 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npx depcheck
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Bump version and push tag
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-      uses: anothrNick/github-tag-action@1.26.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CUSTOM_TAG: v*

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -80,3 +80,14 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npx depcheck
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Bump version and push tag
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+      uses: anothrNick/github-tag-action@1.26.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CUSTOM_TAG: v*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Trigger a release
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      # This step will retry until required check passes
+      # and will fail the whole workflow if the check conclusion is not a success
+      # https://github.com/marketplace/actions/wait-on-check
+      - name: Wait on checks
+        uses: lewagon/wait-on-check-action@v0.1
+        with:
+          ref: master
+          check-name: depcheck # name of the last existing check for push
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20 # seconds
+      - name: Create tag
+        if: ${{ success() }}
+        run: node ../index.js tag --github -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,4 @@ jobs:
           wait-interval: 20 # seconds
       - name: Create tag
         if: ${{ success() }}
-        run: node ../index.js tag --github -v
+        run: node index.js tag --github -v

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ npm i -g @eqworks/release
 
 ## Usage
 
+### Changelog
 In any git repo (suppose the tagging pattern is `v*`, you can use `--pattern` option to fit yours), run:
 
 ```shell
@@ -41,6 +42,8 @@ Which would give you a markdown such as:
 Since v2.0.0, an NLP based auto labelling mechanism has been added, along with the sub-command `changelog` intended for changelog-like formatting (as shown above).
 
 Since v3.0.0, the NLP model has been [retrained](https://github.com/EQWorks/release/pull/20) to adhere to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
+
+### Notes
 
 The original sub-command `notes` can be used for a more "feature" oriented formatting:
 
@@ -75,6 +78,16 @@ Which gives:
 
   * [ADDED, CHANGED] add model training process as a jupyter notebook (1c57956 by Runzhou Li (woozyking))
 ```
+
+
+### Tag
+
+Since v3.1.0, the sub-command `tag` identifies the version inside the commit messages and can either create a local tag with the commit version as its name or make a github release using the `--github` flag
+```shell
+% release tag --github
+```
+Reads from the latest 3 commits (default) and can be changed with the `-n` flag
+
 
 You can learn more about the CLI by typing `release` or `release <command> --help`.
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { notes, changelog } = require('./lib')
+const { notes, changelog, tag } = require('./lib')
 
 if (require.main === module) {
   require('yargs')
@@ -15,6 +15,12 @@ if (require.main === module) {
       changelog.description,
       changelog.options,
       changelog.handler,
+    )
+    .command(
+      tag.command,
+      tag.description,
+      // changelog.options,
+      tag.handler,
     )
     .demandCommand()
     .help()

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ if (require.main === module) {
     .command(
       tag.command,
       tag.description,
-      // changelog.options,
+      tag.options,
       tag.handler,
     )
     .demandCommand()

--- a/lib/command.tag.js
+++ b/lib/command.tag.js
@@ -1,6 +1,6 @@
 const { execSync } = require('child_process')
-const packageJson = require('./package.json')
-
+const packageJson = require('../package.json')
+const { githubHandler } = require('./github')
 
 const versionPattern = /([0-9]\d*\.[0-9]\d*\.[0-9]\d*)(-alpha||-beta)?(-[0-9]\d*)?/
 
@@ -10,10 +10,9 @@ const handler = async () => {
   // array of the top 3 commits in master
   const commits = execSync("git log --no-merges --format='%s' -n 3").toString().trim().split('\n')
   const versionBump = commits.find((commit) => commit.startsWith('version'))
-
   if (!versionBump) {
     console.error('No version bump commit available')
-    process.exit(1)
+    process.exit(0)
   }
 
   const [semver] = versionBump.match(versionPattern) || []
@@ -22,7 +21,11 @@ const handler = async () => {
     console.error('Intended version bump does not match package.json version field')
     process.exit(1)
   }
-
+  try {
+    await githubHandler({ tag: `v${semver}`, action: command })
+  } catch (err) {
+    console.error(err)
+  }
 }
 
 module.exports = { command, description, handler }

--- a/lib/command.tag.js
+++ b/lib/command.tag.js
@@ -1,32 +1,9 @@
-const { execSync } = require('child_process')
-const packageJson = require('../package.json')
-const { githubHandler } = require('./github')
+const { tagOptions: options, tagHandler } = require('./tag-handler')
 
-const versionPattern = /([0-9]\d*\.[0-9]\d*\.[0-9]\d*)(-alpha||-beta)?(-[0-9]\d*)?/
 
 const command = 'tag'
 const description = `Generate ${command} based on last commit message`
-const handler = async () => {
-  // array of the top 3 commits in master
-  const commits = execSync("git log --no-merges --format='%s' -n 3").toString().trim().split('\n')
-  const versionBump = commits.find((commit) => commit.startsWith('version'))
-  if (!versionBump) {
-    console.error('No version bump commit available')
-    process.exit(0)
-  }
+const handler = tagHandler(command)
 
-  const [semver] = versionBump.match(versionPattern) || []
-
-  if (semver !== packageJson.version) {
-    console.error('Intended version bump does not match package.json version field')
-    process.exit(1)
-  }
-  try {
-    await githubHandler({ tag: `v${semver}`, action: command })
-  } catch (err) {
-    console.error(err)
-  }
-}
-
-module.exports = { command, description, handler }
+module.exports = { command, description, options, handler }
 

--- a/lib/command.tag.js
+++ b/lib/command.tag.js
@@ -1,0 +1,29 @@
+const { execSync } = require('child_process')
+const packageJson = require('./package.json')
+
+
+const versionPattern = /([0-9]\d*\.[0-9]\d*\.[0-9]\d*)(-alpha||-beta)?(-[0-9]\d*)?/
+
+const command = 'tag'
+const description = `Generate ${command} based on last commit message`
+const handler = async () => {
+  // array of the top 3 commits in master
+  const commits = execSync("git log --no-merges --format='%s' -n 3").toString().trim().split('\n')
+  const versionBump = commits.find((commit) => commit.startsWith('version'))
+
+  if (!versionBump) {
+    console.error('No version bump commit available')
+    process.exit(1)
+  }
+
+  const [semver] = versionBump.match(versionPattern) || []
+
+  if (semver !== packageJson.version) {
+    console.error('Intended version bump does not match package.json version field')
+    process.exit(1)
+  }
+
+}
+
+module.exports = { command, description, handler }
+

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,5 +1,5 @@
 const { parseCommits, write, log, exec } = require('./utils')
-const { updateRelease } = require('./github')
+const { githubHandler } = require('./github')
 
 
 const INCEPTION = 'INCEPTION'
@@ -83,7 +83,7 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
     if (print) {
       console.log(formatted)
     } else if (github) {
-      await updateRelease({ formatted, tag: version, verbose })
+      await githubHandler({ formatted, tag: version, verbose })
     } else {
       write(command)({ formatted, version, previous, file })
     }

--- a/lib/github.js
+++ b/lib/github.js
@@ -10,6 +10,7 @@ module.exports.githubHandler = async ({
   tag,
   verbose = false,
   action = 'update',
+  isPre = false,
 }) => {
   if (!GITHUB_TOKEN) {
     throw new Error('$GITHUB_TOKEN not set')
@@ -49,7 +50,7 @@ module.exports.githubHandler = async ({
       repo,
       tag_name: tag,
       name: tag,
-      // prerelease: default false
+      prerelease: isPre,
     })
     log(`Release ${tag_name} created based on commit message`, { verbose })
   }

--- a/lib/github.js
+++ b/lib/github.js
@@ -5,7 +5,12 @@ const { exec, log } = require('./utils')
 
 const { GITHUB_TOKEN, GITHUB_OWNER: owner, GITHUB_REPO } = process.env
 
-module.exports.updateRelease = async ({ formatted, tag, verbose }) => {
+module.exports.githubHandler = async ({
+  formatted,
+  tag,
+  verbose = false,
+  action = 'update',
+}) => {
   if (!GITHUB_TOKEN) {
     throw new Error('$GITHUB_TOKEN not set')
   }
@@ -19,20 +24,33 @@ module.exports.updateRelease = async ({ formatted, tag, verbose }) => {
 
   const repo = GITHUB_REPO || _exec('basename `git rev-parse --show-toplevel`').toString().trim()
 
-  const { data: { name, id: release_id } } = await octokit.request('GET /repos/:owner/:repo/releases/tags/:tag', {
-    owner,
-    repo,
-    tag,
-  })
-  log(`Release ${name} (ID: ${release_id}) found based on tag: ${tag}`, { verbose })
-
-  if (release_id) {
-    await octokit.request('PATCH /repos/:owner/:repo/releases/:release_id', {
+  if (action === 'update') {
+    const { data: { name, id: release_id } } = await octokit.request('GET /repos/:owner/:repo/releases/tags/:tag', {
       owner,
       repo,
-      release_id,
-      body: formatted,
+      tag,
     })
-    log(`Release ${name} (ID: ${release_id}) updated with notes: ${formatted}`, { verbose })
+    log(`Release ${name} (ID: ${release_id}) found based on tag: ${tag}`, { verbose })
+
+    if (release_id) {
+      await octokit.request('PATCH /repos/:owner/:repo/releases/:release_id', {
+        owner,
+        repo,
+        release_id,
+        body: formatted,
+      })
+      log(`Release ${name} (ID: ${release_id}) updated with notes: ${formatted}`, { verbose })
+    }
+  }
+
+  if (action === 'tag') {
+    const { data: { tag_name } } = await octokit.request('POST /repos/:owner/:repo/releases', {
+      owner,
+      repo,
+      tag_name: tag,
+      name: tag,
+      // prerelease: default false
+    })
+    log(`Release ${tag_name} created based on commit message`, { verbose })
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const notes = require('./command.notes')
 const changelog = require('./command.changelog')
+const tag = require('./command.tag')
 
-module.exports = { notes, changelog }
+module.exports = { notes, changelog, tag }

--- a/lib/tag-handler.js
+++ b/lib/tag-handler.js
@@ -1,0 +1,56 @@
+const { log, exec } = require('./utils')
+const { githubHandler } = require('./github')
+const packageJson = require('../package.json')
+
+
+module.exports.tagOptions = (yargs) => yargs
+  .option('github', {
+    type: 'boolean',
+    alias: 'gh',
+    description: 'Flag to create a tag from commit version and execute a GitHub release',
+    default: false,
+  }).option('number', {
+    type: 'number',
+    alias: 'n',
+    description: 'Limit the number of commits to read tag from',
+    default: 3,
+  }).option('verbose', {
+    type: 'boolean',
+    alias: 'v',
+    describe: 'Show verbose output',
+    default: false,
+  })
+
+const versionPattern = /([0-9]\d*\.[0-9]\d*\.[0-9]\d*)(-\w*)?(-[0-9]\d*)?/
+
+module.exports.tagHandler = (command) => async ({ github, verbose, number }) => {
+  const _exec = exec({ verbose })
+  try {
+  // default to the top 3 commits in master
+    const commits = _exec(`git log --no-merges --format='%s' -n ${number}`).toString().trim().split('\n')
+    const versionBump = commits.find((commit) => commit.startsWith('version'))
+    if (!versionBump) {
+      console.error('No version bump commit available')
+      process.exit(0)
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    const [tagVersion, semver, preRelease] = versionBump.match(versionPattern) || []
+
+    if (tagVersion !== packageJson.version) {
+      console.error('Intended version bump does not match package.json version field')
+      process.exit(1)
+    }
+    if (github) {
+      await githubHandler({ tag: `v${tagVersion}`, action: command, isPre: Boolean(preRelease) })
+    } else {
+      _exec('git fetch --prune')
+      _exec(`git tag v${tagVersion} -a -m "v${tagVersion}"`)
+    }
+  } catch (err) {
+    if (verbose) {
+      console.error(err)
+    }
+    log(err, { severity: 'error' })
+  }
+}


### PR DESCRIPTION
- custom cli `release tag` to be used with GH workflow on a commit push to master that updates package.json for a release
- currently looking for version in the last 3 commits, not considering merge commits
- commit message has to start with `version` like `version - v3.4.10` or `version/package - v3.4.10`
- the actual semantic version can be of any type: 
```
3.4.10
3.4.10-alpha
3.4.10-beta
3.4.10-alpha-12
v3.4.10
v3.4.10-alpha
v3.4.10-beta
v3.4.10-alpha-12
```


> initially planned based on: https://github.com/anothrNick/github-tag-action
where `DEFAULT_BUMP: none` means that commit message that includes #major, #minor, or #patch will trigger the respective version bump. If two or more are present, the highest-ranking one will take precedence.
