### PR TITLE
[G2M]tag - fix directory access to json

### DIFF
--- a/lib/tag-handler.js
+++ b/lib/tag-handler.js
@@ -1,6 +1,6 @@
 const { log, exec } = require('./utils')
 const { githubHandler } = require('./github')
-const packageJson = require('../package.json')
+const fs = require('fs')
 
 
 module.exports.tagOptions = (yargs) => yargs
@@ -26,9 +26,11 @@ const versionPattern = /([0-9]\d*\.[0-9]\d*\.[0-9]\d*)([-]\w+)?([.]\d+)?/
 module.exports.tagHandler = (command) => async ({ github, verbose, number }) => {
   const _exec = exec({ verbose })
   try {
-  // default to the top 3 commits in master
+    const { version } = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+    // default to the top 3 commits in master
     const commits = _exec(`git log --no-merges --format='%s' -n ${number}`).toString().trim().split('\n')
     const [versionBump] = commits.map((commit) => commit.match(versionPattern)).filter((c) => c)
+
     if (!versionBump) {
       console.error('No version bump commit available')
       process.exit(0)
@@ -36,7 +38,7 @@ module.exports.tagHandler = (command) => async ({ github, verbose, number }) => 
 
     const [tagVersion, , preRelease] = versionBump
 
-    if (tagVersion !== packageJson.version) {
+    if (tagVersion !== version) {
       console.error('Intended version bump does not match package.json version field')
       process.exit(1)
     }


### PR DESCRIPTION
I was statically accessing and cross-referencing JSON version with the `release repo > package.json`
just realized that when I applied this package in other repos:  even though it could identify the version in the commit message, it was never matching package.json 😅  

this should work