### PR TITLE
[G2M]tag - make access to package.json safer

### DIFF
--- a/lib/tag-handler.js
+++ b/lib/tag-handler.js
@@ -26,7 +26,7 @@ const versionPattern = /([0-9]\d*\.[0-9]\d*\.[0-9]\d*)([-]\w+)?([.]\d+)?/
 module.exports.tagHandler = (command) => async ({ github, verbose, number }) => {
   const _exec = exec({ verbose })
   try {
-    const { version } = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+    const { version } = JSON.parse(fs.readFileSync(`${__dirname}/../package.json`, 'utf8'))
     // default to the top 3 commits in master
     const commits = _exec(`git log --no-merges --format='%s' -n ${number}`).toString().trim().split('\n')
     const [versionBump] = commits.map((commit) => commit.match(versionPattern)).filter((c) => c)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",


### PR DESCRIPTION
replace plain 
> JSON.parse(fs.readFileSync(`'./package.json'`, 'utf8'))

with 

> JSON.parse(fs.readFileSync(`${__dirname}/../package.json`, 'utf8'))