### PR TITLE
[G2M]common/baseHandler - filter out revert commits

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -71,11 +71,49 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
     cmd += ' | head -2'
     const [_head, _base] = _exec(cmd).toString().trim().split('\n').filter(t => t)
 
+    const isRevert = /(revert)/gi
+    let _revertCommits = []
     const version = (head || _head || 'HEAD').trim()
     const previous = (base || _base || INCEPTION).trim()
     const diff = `${version}${previous !== INCEPTION ? `...${previous}` : ''}`
     cmd = `git log --no-merges --format='%h::%s::%b::%an||' ${diff}`
-    const logs = _exec(cmd).toString().trim().split('||').map(log => log.trim()).filter(log => log)
+
+    const _logs = _exec(cmd).toString().trim().split('||').map((log) => {
+      if (log) {
+        log.match(isRevert) && _revertCommits.push(log.split('::')[0].replace(/^(\n)/, ''))
+      }
+      return log.trim()
+    })
+
+    /** since we're filtering out merge commits from this flow initially, parents will always have one direct commit */
+    const getParentCmd = (commit) => `git show -s --pretty=%p ${commit}`
+    const parentCommit = (commit) => _exec(getParentCmd(commit)).toString().trim()
+    let revertCommits = [..._revertCommits]
+    if (_revertCommits.length) {
+      _revertCommits.forEach((c) => {
+        const parent = parentCommit(c)
+        /** check if parent is a merge commit */
+        const grandParent = parentCommit(parent).split(' ')
+        const isMergeCommit = grandParent.length > 1
+        if (isMergeCommit) {
+          const commitList = _exec(`git log --format='%h' ${parent}^..${parent}`).toString().trim().split('\n')
+          revertCommits = revertCommits.concat(commitList)
+        } else {
+          revertCommits.push(parent)
+        }
+      })
+    }
+
+    const logs = _logs.filter((log) => {
+      if (log) {
+        const isRevert = revertCommits.some((commit) => {
+          const regex = new RegExp(commit)
+          return log.match(regex)
+        })
+        return !isRevert
+      }
+    })
+
     const parsed = await parseCommits({ logs, verbose })
 
     const formatted = formatter({ parsed, version, previous })

--- a/lib/common.js
+++ b/lib/common.js
@@ -45,6 +45,11 @@ module.exports.options = (yargs) => yargs
     alias: 'v',
     describe: 'Show verbose output',
     default: false,
+  }).option('remove-revert', {
+    type: 'boolean',
+    alias: 'rr',
+    describe: 'Remove revert commits',
+    default: false,
   })
 
 module.exports.baseHandler = ({ command, formatter }) => async ({
@@ -57,6 +62,7 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
   print,
   fetch,
   verbose,
+  'remove-revert': revert,
 }) => {
   const _exec = exec({ verbose })
   try {
@@ -79,7 +85,7 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
     cmd = `git log --no-merges --format='%h::%s::%b::%an||' ${diff}`
 
     const _logs = _exec(cmd).toString().trim().split('||').map((log) => {
-      if (log) {
+      if (revert) {
         log.match(isRevert) && _revertCommits.push(log.split('::')[0].replace(/^(\n)/, ''))
       }
       return log.trim()
@@ -105,13 +111,14 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
     }
 
     const logs = _logs.filter((log) => {
-      if (log) {
+      if (revert && log) {
         const isRevert = revertCommits.some((commit) => {
           const regex = new RegExp(commit)
           return log.match(regex)
         })
         return !isRevert
       }
+      return log
     })
 
     const parsed = await parseCommits({ logs, verbose })


### PR DESCRIPTION
> optional flag `--remove-revert` or `--rr` default to false

- this would be a crafty way to recognize the revert commits but it is flawed in the way that if someone uses the `revert` word in their commit, I'll be removing at least 2 commits out of the final results. 
- Commits considered for removal are logged with the `verbose` flag.

![image](https://user-images.githubusercontent.com/53827690/106816080-d574ac00-6642-11eb-8932-9c4c311ff0e6.png)

![image](https://user-images.githubusercontent.com/53827690/106815991-b5dd8380-6642-11eb-90e4-8ee895deba89.png)

![image](https://user-images.githubusercontent.com/53827690/106816103-e2919b00-6642-11eb-9de9-f25551863a0c.png)

![image](https://user-images.githubusercontent.com/53827690/106816171-fe953c80-6642-11eb-9913-af4f2a4bff86.png)
