### PR TITLE
[G2M] attempt to fix json version reading

### DIFF
--- a/lib/tag-handler.js
+++ b/lib/tag-handler.js
@@ -26,21 +26,21 @@ const versionPattern = /([0-9]\d*\.[0-9]\d*\.[0-9]\d*)([-]\w+)?([.]\d+)?/
 module.exports.tagHandler = (command) => async ({ github, verbose, number }) => {
   const _exec = exec({ verbose })
   try {
-    const { version } = JSON.parse(fs.readFileSync(`${__dirname}/../package.json`, 'utf8'))
+    const { version } = JSON.parse(fs.readFileSync(`${process.cwd()}/package.json`, 'utf8'))
     // default to the top 3 commits in master
     const commits = _exec(`git log --no-merges --format='%s' -n ${number}`).toString().trim().split('\n')
     const [versionBump] = commits.map((commit) => commit.match(versionPattern)).filter((c) => c)
 
     if (!versionBump) {
-      console.error('No version bump commit available')
+      log('No version bump commit available', { verbose: true, severity: 'warning' })
       process.exit(0)
     }
 
     const [tagVersion, , preRelease] = versionBump
 
     if (tagVersion !== version) {
-      console.error('Intended version bump does not match package.json version field')
-      process.exit(1)
+      log('Intended version bump does not match package.json version field', { verbose: true, severity: 'warning' })
+      process.exit(0)
     }
     if (github) {
       await githubHandler({ tag: `v${tagVersion}`, action: command, isPre: Boolean(preRelease) })
@@ -52,6 +52,6 @@ module.exports.tagHandler = (command) => async ({ github, verbose, number }) => 
     if (verbose) {
       console.error(err)
     }
-    log(err, { severity: 'error' })
+    log(err, { verbose: true, severity: 'error' })
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "3.2.1",
+  "version": "3.3.0-alpha.1",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",


### PR DESCRIPTION
I think it was always reading from this repo itself instead of the working directory. Would like to try this out:

Error handling: not fail the process to avoid gh action failed due to auto-release but always log the outcomes in case it's not successful
![image](https://user-images.githubusercontent.com/53827690/107523188-794de280-6b82-11eb-825e-7c96baa23ea3.png)
 an actual error: (here the verbose mode would give more details, this ss would be without `-v` flag)
![image](https://user-images.githubusercontent.com/53827690/107523260-88cd2b80-6b82-11eb-934c-ed3a3ebc0cb0.png) 
