### PR TITLE
[G2M] Feature/new contributors

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -124,7 +124,25 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
     const ghContributions = await githubHandler({ action: 'contributions' })
     const parsed = await parseCommits({ logs, verbose, ghContributions })
 
-    const formatted = formatter({ parsed, version, previous })
+    const pastContributors = new Set()
+    for (let page = 1; page <= 5; page++) { // max 500 commits
+      const nextPage = await githubHandler({ tag: previous, action: 'contributions', page })
+      nextPage.map(({ login }) => login).forEach(pastContributors.add, pastContributors)
+      if (!nextPage.length) {
+        break
+      }
+    }
+    const newContributors = ghContributions.reduce((acc, { login }) => {
+      if (!pastContributors.has(login)) {
+        if (!acc[login]) {
+          acc[login] = 0
+        }
+        acc[login]++
+      }
+      return acc
+    }, {})
+
+    const formatted = formatter({ parsed, version, previous, newContributors })
 
     if (print) {
       console.log(formatted)

--- a/lib/common.js
+++ b/lib/common.js
@@ -121,7 +121,8 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
       return log
     })
 
-    const parsed = await parseCommits({ logs, verbose })
+    const ghContributions = await githubHandler({ action: 'contributions' })
+    const parsed = await parseCommits({ logs, verbose, ghContributions })
 
     const formatted = formatter({ parsed, version, previous })
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -81,6 +81,7 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
     let _revertCommits = []
     const version = (head || _head || 'HEAD').trim()
     const previous = (base || _base || INCEPTION).trim()
+    const previousHash = _exec(`git rev-parse --short ${previous}`).toString().trim()
     const diff = `${version}${previous !== INCEPTION ? `...${previous}` : ''}`
     cmd = `git log --no-merges --format='%h::%s::%b::%an||' ${diff}`
 
@@ -122,6 +123,7 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
     })
 
     const ghContributions = await githubHandler({ action: 'contributions' })
+      .then(r => r.slice(0, r.map(({ sha }) => sha).indexOf(previousHash)))
     const parsed = await parseCommits({ logs, verbose, ghContributions })
 
     const pastContributors = new Set()
@@ -132,17 +134,18 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
         break
       }
     }
-    const newContributors = ghContributions.reduce((acc, { login }) => {
-      if (!pastContributors.has(login)) {
-        if (!acc[login]) {
-          acc[login] = 0
+    const contributors = ghContributions.reduce((acc, { login }) => {
+      if (!acc[login]) {
+        acc[login] = {
+          commits: 0,
+          fresh: !pastContributors.has(login),
         }
-        acc[login]++
       }
+      acc[login].commits++
       return acc
     }, {})
 
-    const formatted = formatter({ parsed, version, previous, newContributors })
+    const formatted = formatter({ parsed, version, previous, contributors })
 
     if (print) {
       console.log(formatted)

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,4 +1,13 @@
-module.exports.notes = ({ parsed, version, previous }) => {
+const newContributorsReport = (newContributors) => {
+  let res = ''
+  if (Object.keys(newContributors).length) {
+    res += '\n\n# New Contributors 🎉\n'
+    Object.entries(newContributors).forEach(([login, count]) => res += `\n- [**${login}**](https://github.com/${login}) (${count} commits)`)
+  }
+  return res
+}
+
+module.exports.notes = ({ parsed, version, previous, newContributors }) => {
   // group by T1 & T2, enrich msg with label
   const byT1 = parsed.reduce((acc, { t1, labels, msg }) => {
     // to organize commits without T2
@@ -30,10 +39,11 @@ module.exports.notes = ({ parsed, version, previous }) => {
       })
     })
   })
+  notes += newContributorsReport(newContributors)
   return `${notes}\n`
 }
 
-module.exports.changelog = ({ parsed, version, previous }) => {
+module.exports.changelog = ({ parsed, version, previous, newContributors }) => {
   // group by first label (most scored)
   const byLabel = parsed.reduce((acc, { t1, labels, msg }) => {
     const label = labels[0] || 'CHANGED'
@@ -51,5 +61,6 @@ module.exports.changelog = ({ parsed, version, previous }) => {
       }
     })
   })
+  changelog += newContributorsReport(newContributors)
   return `${changelog}\n`
 }

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,13 +1,11 @@
-const newContributorsReport = (newContributors) => {
-  let res = ''
-  if (Object.keys(newContributors).length) {
-    res += '\n\n# New Contributors 🎉\n'
-    Object.entries(newContributors).forEach(([login, count]) => res += `\n- [**${login}**](https://github.com/${login}) (${count} commits)`)
-  }
-  return res
-}
+const contributorsReport = (contributors) => (
+  Object.entries(contributors).reduce((acc, [login, { commits, fresh }], i) => {
+    acc += `${i === 0 ? '\n\n# Contributors: \n' : ''}\n- [**${login}**](https://github.com/${login}) (${fresh ? '🎉 fresh contributor, ' : ''}${commits} commits)`
+    return acc
+  }, '')
+)
 
-module.exports.notes = ({ parsed, version, previous, newContributors }) => {
+module.exports.notes = ({ parsed, version, previous, contributors }) => {
   // group by T1 & T2, enrich msg with label
   const byT1 = parsed.reduce((acc, { t1, labels, msg }) => {
     // to organize commits without T2
@@ -39,11 +37,11 @@ module.exports.notes = ({ parsed, version, previous, newContributors }) => {
       })
     })
   })
-  notes += newContributorsReport(newContributors)
+  notes += contributorsReport(contributors)
   return `${notes}\n`
 }
 
-module.exports.changelog = ({ parsed, version, previous, newContributors }) => {
+module.exports.changelog = ({ parsed, version, previous, contributors }) => {
   // group by first label (most scored)
   const byLabel = parsed.reduce((acc, { t1, labels, msg }) => {
     const label = labels[0] || 'CHANGED'
@@ -61,6 +59,6 @@ module.exports.changelog = ({ parsed, version, previous, newContributors }) => {
       }
     })
   })
-  changelog += newContributorsReport(newContributors)
+  changelog += contributorsReport(contributors)
   return `${changelog}\n`
 }

--- a/lib/github.js
+++ b/lib/github.js
@@ -11,6 +11,7 @@ module.exports.githubHandler = async ({
   verbose = false,
   action = 'update',
   isPre = false,
+  ...rest
 }) => {
   if (!GITHUB_TOKEN) {
     throw new Error('$GITHUB_TOKEN not set')
@@ -53,5 +54,21 @@ module.exports.githubHandler = async ({
       prerelease: isPre,
     })
     log(`Release ${tag_name} created based on commit message`, { verbose })
+  }
+
+  if (action === 'contributions') {
+    const { data } = await octokit.request('GET /repos/:owner/:repo/commits', {
+      owner,
+      repo,
+      sha: tag,
+      per_page: 100,
+      ...rest,
+    })
+    return data
+      .filter(({ author }) => author)
+      .map(({ sha, author: { login } }) => ({
+        sha: _exec(`git rev-parse --short ${sha}`).toString().trim(),
+        login,
+      }))
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,14 +59,20 @@ module.exports.parseRaw = async (logs = []) => {
   }
 }
 
-module.exports.parseCommits = async ({ logs, verbose = false }) => {
+module.exports.parseCommits = async ({ logs, verbose = false, ghContributions }) => {
   try {
     await model.load()
     return await Promise.all(logs.map(async (line) => {
       const [h, s, b, an] = line.split('::')
       const labels = (await model.predict(s.toLowerCase()) || []).map(({ label }) => label)
       const [t1, t2, message] = parseSubject(s)
-      const msg = { s: `${message} (${h} by ${an})`, t2 }
+      const { login } = ghContributions.find(({ sha }) => sha === h) || {}
+      const msg = {
+        s: `${message} (${h} by ${login ?
+          `[${an}](https://github.com/${login})`
+          : an
+        })`, t2,
+      }
       if (b.trim()) {
         msg.b = b.trim()
       }


### PR DESCRIPTION
### [ref](https://eqworks.slack.com/archives/CB7557258/p1640184445014200)

---

- compute info about new contributors and include it in `notes` and `changelog`
- add hyperlink to commit author if a GitHub username was found to be associated with the commit via GH API

---

# Example:

The following example was generated by using `@eqworks/release notes --pattern="dev-*"` in the `legion` project:

## org

[FIXED] fix util import (8460687 by [Kyle Grimsrud-Manz](https://github.com/vxsl))


## release

[FIXED] correctly interpret non-semver dev stage (52fcba0 by [Kyle Grimsrud-Manz](https://github.com/vxsl))


## product

[FIXED] getSetLock to respond key in hard failure case (8cd3403 by [Runzhou Li (woozyking)](https://github.com/woozyking))
[CHANGED] more generic lock key mechanism (af8fc72 by [Runzhou Li (woozyking)](https://github.com/woozyking))


## products

[CHANGED] include 5-min floor as a part of default lock keys (78e10d4 by [Runzhou Li (woozyking)](https://github.com/woozyking))


# Contributors: 

- [**vxsl**](https://github.com/vxsl) (🎉 fresh contributor, 3 commits)
- [**woozyking**](https://github.com/woozyking) (4 commits)

