### PR TITLE
[G2M] commit author formatting, dependency tracing

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,6 +1,6 @@
 const contributorsReport = (contributors) => (
   Object.entries(contributors || {}).reduce((acc, [login, { commits, fresh }], i) => {
-    acc += `${i === 0 ? '\n\n# Contributors: \n' : ''}\n- [**${login}**](https://github.com/${login}) (${fresh ? '🎉 fresh contributor, ' : ''}${commits} commits)`
+    acc += `${i === 0 ? '\n\n# Contributors: \n' : ''}\n- [@${login}](https://github.com/${login}) (${fresh ? '🎉 fresh contributor, ' : ''}${commits} commits)`
     return acc
   }, '')
 )

--- a/lib/github.js
+++ b/lib/github.js
@@ -3,7 +3,8 @@ const { Octokit } = require('@octokit/core')
 const { exec, log } = require('./utils')
 
 
-const { GITHUB_TOKEN, GITHUB_OWNER: owner, GITHUB_REPO } = process.env
+const { GITHUB_TOKEN, GITHUB_OWNER: owner = 'eqworks', GITHUB_REPO } = process.env
+
 
 module.exports.githubHandler = async ({
   formatted,
@@ -15,10 +16,6 @@ module.exports.githubHandler = async ({
 }) => {
   if (!GITHUB_TOKEN) {
     throw new Error('$GITHUB_TOKEN not set')
-  }
-
-  if (!owner) {
-    throw new Error('$GITHUB_OWNER not set')
   }
 
   const _exec = exec({ verbose })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,15 +63,14 @@ module.exports.parseCommits = async ({ logs, verbose = false, ghContributions = 
   try {
     await model.load()
     return await Promise.all(logs.map(async (line) => {
-      const [h, s, b, an] = line.split('::')
+      const [h, s, b, an] = line.split('::') // hash, subject, body, author
       const labels = (await model.predict(s.toLowerCase()) || []).map(({ label }) => label)
       const [t1, t2, message] = parseSubject(s)
+      // find GitHub author's login handle through ghContributions
       const { login } = ghContributions.find(({ sha }) => sha === h) || {}
       const msg = {
-        s: `${message} (${h} by ${login ?
-          `[${an}](https://github.com/${login})`
-          : an
-        })`, t2,
+        s: `${message} (${h} by ${login ? `[@${login}](https://github.com/${login})` : an})`,
+        t2,
       }
       if (b.trim()) {
         msg.b = b.trim()

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,14 +1,34 @@
 const fs = require('fs')
 const { execSync } = require('child_process')
 
+const { Octokit } = require('@octokit/core')
 const chalk = require('chalk')
 const FastText = require('fasttext.js')
 
+const { GITHUB_TOKEN } = process.env
+
+// TODO: it makes more sense in the ./github.js module, but it'd cause circular dependency with this module
+const getGHRelease = ({ owner, repo, tag }) => {
+  if (!GITHUB_TOKEN) {
+    return {}
+  }
+
+  const octokit = new Octokit({ auth: GITHUB_TOKEN })
+
+  return octokit.request('GET /repos/:owner/:repo/releases/tags/:tag', {
+    owner,
+    repo,
+    tag,
+  })
+}
 
 // model/training data from https://github.com/gesteves91/fasttext-commit-classification
 // training/prediction through https://github.com/loretoparisi/fasttext.js
 const model = new FastText({ loadModel: `${__dirname}/../bin/commits.bin` })
-const R = /(?<cat>\S+?)(\/(?<t2>\S+))? - (?<title>.*)/
+
+// Regex patterns
+const COMMIT_MSG = /(?<cat>\S+?)(\/(?<t2>\S+))? - (?<title>.*)/
+const NPM_DEP = /(@(?<pkg_name>\w*\/\w+))\s+((from){0,1}\s*(?<from_ver>v[\w.-]+|\w+-\w+)\s+)*((to){0,1}\s*(?<to_ver>v[\w.-]+|\w+-\w+))/ig
 
 const getColors = (severity) => ({
   info: { bgColor: 'bgCyanBright', color: 'black' },
@@ -30,7 +50,7 @@ module.exports.exec = ({ verbose }) => (cmd) => {
 }
 
 const parseSubject = (s) => {
-  const matches = s.match(R)
+  const matches = s.match(COMMIT_MSG)
   // unmatched to generic "others" category
   if (!matches) {
     return ['others', 'others', s]
@@ -69,11 +89,38 @@ module.exports.parseCommits = async ({ logs, verbose = false, ghContributions = 
       // find GitHub author's login handle through ghContributions
       const { login } = ghContributions.find(({ sha }) => sha === h) || {}
       const msg = {
-        s: `${message} (${h} by ${login ? `[@${login}](https://github.com/${login})` : an})`,
+        s: `${message} (${h} by ${login ? `[@${login}](https://github.com/${login})` : an})\n`,
         t2,
       }
       if (b.trim()) {
         msg.b = b.trim()
+      }
+      // extract npm package names from commit message
+      const matches = message.matchAll(NPM_DEP)
+      for (const m of matches) {
+        const {
+          groups: {
+            pkg_name,
+            to_ver,
+            // from_ver, // TODO: from_ver not used yet
+          },
+        } = m
+        // TODO: check against GitHub releases of the mentioned package repo
+        const [owner, repo] = pkg_name.split('/')
+        try {
+          const { data: { html_url, body } = {} } = await getGHRelease({ owner, repo, tag: to_ver })
+          if (!html_url) {
+            continue
+          }
+          // attach link to GitHub release
+          msg.b = `${msg.b || ''}\n[${pkg_name}@${to_ver} release](${html_url}):`
+          // attach to release body as indented quote block
+          if ((body || '').length) {
+            msg.b += `\n${body.split('\n').map(l => `> ${l}`).join('\n')}\n`
+          }
+        } catch (e) {
+          log(`Unable to trace ${pkg_name} release info (${e.message})`, { verbose, severity: 'warning' })
+        }
       }
       return { t1, labels, msg }
     }))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "3.5.0-alpha.1",
+  "version": "3.5.0-alpha.2",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,9 +18,9 @@
     strip-json-comments "^3.1.1"
 
 "@humanwhocodes/config-array@^0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
-  integrity sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.3.tgz#f2564c744b387775b436418491f15fce6601f63e"
+  integrity sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
@@ -84,15 +84,15 @@
     once "^1.4.0"
 
 "@octokit/request@^5.6.0":
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.2.tgz#1aa74d5da7b9e04ac60ef232edd9a7438dcf32d8"
-  integrity sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
+  integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
   dependencies:
     "@octokit/endpoint" "^6.0.1"
     "@octokit/request-error" "^2.1.0"
     "@octokit/types" "^6.16.1"
     is-plain-object "^5.0.0"
-    node-fetch "^2.6.1"
+    node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
 "@octokit/types@^6.0.3", "@octokit/types@^6.16.1":
@@ -559,10 +559,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-node-fetch@^2.6.1:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
rolling from #52 

deps tracing idea came from past conversation with @geoerika (and/or some other ppl, sry forgot)

- more consistent per-commit author name using github `@login` handle if available from github contribution metadata
- trace npm package pattern to hit github repo releases API to embed into per-message updates (as link and blockquote if available)

![dep trace](https://user-images.githubusercontent.com/2837532/151460631-09892148-02fe-4a34-a58e-7fe002ab9c71.png)

