### PR TITLE
[G2M] more contributors stats, speed up contributions stats pulling

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -134,20 +134,29 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
       ghContributions = await githubHandler({ tag: shas[0], action: 'contributions' })
         .then(r => r.filter(({ sha }) => shas.includes(sha))) // all shas shorthanded through git rev-parse --short
       const pastContributors = new Set()
+      let since = new Date().toISOString()
       for (let page = 1; page <= 5; page++) { // max 500 commits
         const nextPage = await githubHandler({ tag: previous, action: 'contributions', page })
-        nextPage.map(({ login }) => login).forEach(pastContributors.add, pastContributors)
         if (!nextPage.length) {
           break
         }
+        nextPage.forEach(({ login, date }) => {
+          pastContributors.add(login)
+          if (date < since) {
+            since = date // update furthest "at least since" datetime based on the lookback pages
+          }
+        })
       }
-      payload.contributors = ghContributions.reduce((acc, { login }) => {
+      payload.since = since // would be used to claim "fresh contributor since at least YYYY-MM-DD...""
+      payload.contributors = ghContributions.reduce((acc, { login, date }) => {
         if (!acc[login]) {
           acc[login] = {
             commits: 0,
             fresh: !pastContributors.has(login),
+            days: new Set(),
           }
         }
+        acc[login].days.add(date.split('T')[0]) // only care about days
         acc[login].commits++
         return acc
       }, {})

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,11 +1,21 @@
-const contributorsReport = (contributors) => (
-  Object.entries(contributors || {}).reduce((acc, [login, { commits, fresh }], i) => {
-    acc += `${i === 0 ? '\n\n# Contributors: \n' : ''}\n- [@${login}](https://github.com/${login}) (${fresh ? '🎉 fresh contributor, ' : ''}${commits} commits)`
-    return acc
-  }, '')
-)
+const contributorsReport = ({ contributors, since }) => {
+  if (!Object.keys(contributors).length) {
+    return ''
+  }
+  let r = '\n\n# Contributors:\n'
+  Object.entries(contributors || {}).forEach(([login, { commits, fresh, days } ]) => {
+    r += `\n- [@${login}](https://github.com/${login})`
+    if (fresh) {
+      r += ` (🎉 fresh contributor with ${commits} commits in ${days.size} day${days > 1 ? 's' : ''} since at least ${since.split('T')[0]})`
+    } else {
+      r += ` (with ${commits} commits in ${days.size} day${days > 1 ? 's' : ''})`
+    }
+  })
+  return r
+}
 
-module.exports.notes = ({ parsed, version, previous, contributors }) => {
+module.exports.notes = (payload) => {
+  const { parsed, version, previous } = payload
   // group by T1 & T2, enrich msg with label
   const byT1 = parsed.reduce((acc, { t1, labels, msg }) => {
     // to organize commits without T2
@@ -37,11 +47,12 @@ module.exports.notes = ({ parsed, version, previous, contributors }) => {
       })
     })
   })
-  notes += contributorsReport(contributors)
+  notes += contributorsReport(payload)
   return `${notes}\n`
 }
 
-module.exports.changelog = ({ parsed, version, previous, contributors }) => {
+module.exports.changelog = (payload) => {
+  const { parsed, version, previous } = payload
   // group by first label (most scored)
   const byLabel = parsed.reduce((acc, { t1, labels, msg }) => {
     const label = labels[0] || 'CHANGED'
@@ -59,6 +70,6 @@ module.exports.changelog = ({ parsed, version, previous, contributors }) => {
       }
     })
   })
-  changelog += contributorsReport(contributors)
+  changelog += contributorsReport(payload)
   return `${changelog}\n`
 }

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -5,10 +5,12 @@ const contributorsReport = ({ contributors, since }) => {
   let r = '\n\n# Contributors:\n'
   Object.entries(contributors || {}).forEach(([login, { commits, fresh, days } ]) => {
     r += `\n- [@${login}](https://github.com/${login})`
+    // commit stats (count and days)
+    const cs = `${commits} commit${commits > 1 ? 's' : ''} across ${days.size} day${days.size > 1 ? 's' : ''}`
     if (fresh) {
-      r += ` (🎉 fresh contributor with ${commits} commits in ${days.size} day${days > 1 ? 's' : ''} since at least ${since.split('T')[0]})`
+      r += ` (🎉 fresh contributor since at least ${since.split('T')[0]} - ${cs})`
     } else {
-      r += ` (with ${commits} commits in ${days.size} day${days > 1 ? 's' : ''})`
+      r += ` (returning contributor - ${cs})`
     }
   })
   return r

--- a/lib/github.js
+++ b/lib/github.js
@@ -63,6 +63,7 @@ module.exports.githubHandler = async ({
     })
     return data
       .filter(({ author }) => author)
+      .filter(({ parents }) => (parents || []).length === 1) // filter out merge commits (parents.length > 1)
       .map(({ sha, author: { login } }) => ({
         sha: sha.slice(0, 7), // 7 seems to be a decent default length for short sha-1 hash
         login,

--- a/lib/github.js
+++ b/lib/github.js
@@ -62,8 +62,7 @@ module.exports.githubHandler = async ({
       ...rest,
     })
     return data
-      .filter(({ author }) => author) // filter missing author/bot commits
-      .filter(({ parents }) => (parents || []).length === 1) // filter out merge commits (parents.length > 1)
+       .filter(({ author, parents }) => author && parents?.length === 1)
       .map(({ sha, author: { login }, commit: { committer: { date } } }) => ({
         sha: sha.slice(0, 7), // 7 seems to be a decent default length for short sha-1 hash
         login,

--- a/lib/github.js
+++ b/lib/github.js
@@ -53,20 +53,21 @@ module.exports.githubHandler = async ({
     log(`Release ${tag_name} created based on commit message`, { verbose })
   }
 
-  if (action === 'contributions') {
+  if (action === 'contributions') { // TODO: include other types of contributions, such as issue authors
     const { data } = await octokit.request('GET /repos/:owner/:repo/commits', {
       owner,
       repo,
       sha: tag,
-      per_page: 100,
+      per_page: 100, // GitHub API max (as-of 2022 Jan 28)
       ...rest,
     })
     return data
-      .filter(({ author }) => author)
+      .filter(({ author }) => author) // filter missing author/bot commits
       .filter(({ parents }) => (parents || []).length === 1) // filter out merge commits (parents.length > 1)
-      .map(({ sha, author: { login } }) => ({
+      .map(({ sha, author: { login }, commit: { committer: { date } } }) => ({
         sha: sha.slice(0, 7), // 7 seems to be a decent default length for short sha-1 hash
         login,
+        date, // commiter datetime is used
       }))
   }
 }

--- a/lib/github.js
+++ b/lib/github.js
@@ -64,7 +64,7 @@ module.exports.githubHandler = async ({
     return data
       .filter(({ author }) => author)
       .map(({ sha, author: { login } }) => ({
-        sha: _exec(`git rev-parse --short ${sha}`).toString().trim(),
+        sha: sha.slice(0, 7), // 7 seems to be a decent default length for short sha-1 hash
         login,
       }))
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "3.5.0-alpha.2",
+  "version": "3.5.0-alpha.3",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",


### PR DESCRIPTION
## Resolve the "contributions" action performance bottleneck

The bottleneck is at the synchronous local `git` CLI command (rev-parse to obtain the short hash).

One option is to batch invoke asynchronously.

But since it's anyway a "best-effort" abbreviation, quoting from [git doc on config `core.abbrev`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev):

> Set the length object names are abbreviated to. If unspecified or set to "auto", an appropriate value is computed based on the approximate number of packed objects in your repository, which hopefully is enough for abbreviated object names to stay unique for some time. If set to "no", no abbreviation is made and the object names are shown in their full length. The minimum length is 4.

This leads to the current default for most git repos in human history, 7 is good enough, especially considering that for our use-case the lookup is anyway finite based on the `diff` range. As a result, this roughly translates to a 4x-6x speed up (basically down from GitHub API call + N x `git rev-parse` calls, to just GitHub API call, in my test that happened to be down from ~2s to ~300-500ms)

## contributors recency stats

eg:

> - [@woozyking](https://github.com/woozyking) (with 3 commits in 1 day)
> - [@vxsl](https://github.com/vxsl) (🎉 fresh contributor with 5 commits in 1 day since at least 2020-03-26)

also, filter out merge commits from the contributions dataset