### PR TITLE
[G2M] Deps trace fix

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -131,7 +131,7 @@ module.exports.baseHandler = ({ command, formatter }) => async ({
     let ghContributions = []
     if (Boolean(GITHUB_TOKEN) && contrib) { // TODO: the look up can be time-consuming, seek ways to optimize
       const shas = logs.map(l => l.split('::')[0]) // commit filter-set
-      ghContributions = await githubHandler({ tag: shas[0], action: 'contributions' })
+      ghContributions = await githubHandler({ tag: shas[0], action: 'contributions' }) // TODO: local commits would result in empty contributions for now
         .then(r => r.filter(({ sha }) => shas.includes(sha))) // all shas shorthanded through git rev-parse --short
       const pastContributors = new Set()
       let since = new Date().toISOString()

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,5 +1,5 @@
 const contributorsReport = ({ contributors, since }) => {
-  if (!Object.keys(contributors).length) {
+  if (!Object.keys(contributors || {}).length) {
     return ''
   }
   let r = '\n\n# Contributors:\n'

--- a/lib/github.js
+++ b/lib/github.js
@@ -60,9 +60,9 @@ module.exports.githubHandler = async ({
       sha: tag,
       per_page: 100, // GitHub API max (as-of 2022 Jan 28)
       ...rest,
-    })
+    }).catch(() => ({ data: [] }))
     return data
-       .filter(({ author, parents }) => author && parents?.length === 1)
+      .filter(({ author, parents }) => author && (parents || []).length === 1)
       .map(({ sha, author: { login }, commit: { committer: { date } } }) => ({
         sha: sha.slice(0, 7), // 7 seems to be a decent default length for short sha-1 hash
         login,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,7 +28,7 @@ const model = new FastText({ loadModel: `${__dirname}/../bin/commits.bin` })
 
 // Regex patterns
 const COMMIT_MSG = /(?<cat>\S+?)(\/(?<t2>\S+))? - (?<title>.*)/
-const NPM_DEP = /(@(?<pkg_name>\w*\/\w+))\s+((from){0,1}\s*(?<from_ver>v[\w.-]+|\w+-\w+)\s+)*((to){0,1}\s*(?<to_ver>v[\w.-]+|\w+-\w+))/ig
+const NPM_DEP = /(@(?<pkg_name>[\w.-]*\/[\w.-]+))\s+((from){0,1}\s*(?<from_ver>v[\w.-]+|\w+-\w+)\s+)*((to){0,1}\s*(?<to_ver>v[\w.-]+|\w+-\w+))/ig
 
 const getColors = (severity) => ({
   info: { bgColor: 'bgCyanBright', color: 'black' },
@@ -113,7 +113,7 @@ module.exports.parseCommits = async ({ logs, verbose = false, ghContributions = 
             continue
           }
           // attach link to GitHub release
-          msg.b = `${msg.b || ''}\n[${pkg_name}@${to_ver} release](${html_url}):`
+          msg.b = `${msg.b || ''}\n- [${pkg_name}@${to_ver} release](${html_url})`
           // attach to release body as indented quote block
           if ((body || '').length) {
             msg.b += `\n${body.split('\n').map(l => `> ${l}`).join('\n')}\n`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "3.5.0-alpha.3",
+  "version": "3.5.0-alpha.4",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",


### PR DESCRIPTION
- fix deps tracing on org/package that contains `-` characters
- gracefully omit contributions stats if the command is run against local commits (that are not sync'ed to remote yet)
  - in the future this may be more elegantly resolved by carving out the latest `origin` matching branch `HEAD` as the tag/sha, and splice in the local commit with best-effort matching of the contributors/authors (string/pattern matching?)