### PR TITLE
[G2M] node - fix fasttext_wasm error 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-experimental-fetch
 const { notes, changelog, tag } = require('./lib')
 
 if (require.main === module) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   "repository": "git@github.com:EQWorks/release.git",
   "author": "EQ Devs <dev@eqworks.com>",
   "scripts": {
-    "local": "env $(print-env) node index.js",
+    "local": "env $(print-env) node --no-experimental-fetch index.js",
     "lint": "yarn eslint .",
     "prepublishOnly": "yarn lint"
   },
   "dependencies": {
     "@octokit/core": "^3.1.2",
     "chalk": "^4.1.0",
-    "fasttext.js": "^1.1.2",
+    "fasttext.js": "^1.1.4",
     "yargs": "^15.1.0"
   },
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,10 +363,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fasttext.js@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fasttext.js/-/fasttext.js-1.1.2.tgz#63ec2bf63476a9aaa64a89b85cf14c9863ffff87"
-  integrity sha512-ZdH7lJzOlHd2KfT5sr3Z88EQDiEKQzxt+v2J7t1ZVZZhmtM5XZtCQNVDD/wWRNl5zEjv8LBrBoRGTIpcMX52Vw==
+fasttext.js@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/fasttext.js/-/fasttext.js-1.1.4.tgz#22bb550b996a671620baa6e0e6116cb802de1c23"
+  integrity sha512-5nfcVvXb00t6+JlZy16yRREGnMEVoDtFmwSNvneJXh3x/Td5fF+2VTeCFl418RdO5bbPuD59qhe441VuwkbrfA==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
**Issue:** Failed to generate release notes when running on Node 18. (https://eqworks.slack.com/archives/G1FDULP1R/p1687793352537449?thread_ts=1687792888.126619&cid=G1FDULP1R)

**Solution:** Node 18 introduces a new experimental fetch API that causes an error, which can be resolved by disabling it using the `--no-experimental-fetch` flag.
(https://github.com/loretoparisi/fasttext.js/issues/35)
