### PR TITLE
[G2M] Readme - update readme.md with Node.js 18 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,12 @@ Since v3.1.0, the sub-command `tag` identifies the version inside the commit mes
 ```
 
 The above command reads from the latest three commits (by default, change with the `-n` flag.)
+
+## Important note for Node.js 18
+
+When running the CLI commands on Node.js 18, you may need to add the `--no-experimental-fetch` flag to the `NODE_OPTIONS` environment variable. This flag is required to disable the experimental fetch feature introduced in Node.js 18.
+
+To execute the CLI commands with the `--no-experimental-fetch` flag, use the following syntax:
+
+```shell
+% NODE_OPTIONS=--no-experimental-fetch npx @eqworks/release <command>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-experimental-fetch
+#!/usr/bin/env node
 const { notes, changelog, tag } = require('./lib')
 
 if (require.main === module) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "3.5.3-alpha.1",
+  "version": "3.5.3",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "3.5.2",
+  "version": "3.5.3-alpha.0",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/release",
-  "version": "3.5.3-alpha.0",
+  "version": "3.5.3-alpha.1",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",


### PR DESCRIPTION
### Changes:
- remove '--no-experimental-fetch' flag
  (Because it would cause a 'node: bad option: --no-experimental-fetch' error when running the node with a version that is less than or equal to 14.)
- update readme.md with Node.js 18 instructions
 
![Screenshot 2023-06-27 at 3 11 36 PM](https://github.com/EQWorks/release/assets/76548841/2d2fceb9-a5d1-4d26-bf13-bfc3f1e6a14b)
